### PR TITLE
package com.example.dearlog.activity;  import android.graphics.Color;…

### DIFF
--- a/app/src/main/java/com/example/dearlog/activity/DiaryDetailActivity.java
+++ b/app/src/main/java/com/example/dearlog/activity/DiaryDetailActivity.java
@@ -1,18 +1,30 @@
 package com.example.dearlog.activity;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.JsonArrayRequest;
+import com.android.volley.toolbox.Volley;
 import com.example.dearlog.R;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class DiaryDetailActivity extends AppCompatActivity {
 
     private ImageButton btnBack, btnMenu;
     private ImageView imgEmotionColor;
     private TextView tvDate, tvQuestion, tvContent;
+    private RequestQueue queue;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -26,11 +38,19 @@ public class DiaryDetailActivity extends AppCompatActivity {
         tvDate = findViewById(R.id.tv_diary_date);
         tvQuestion = findViewById(R.id.tv_question);
         tvContent = findViewById(R.id.tv_diary_content);
+        queue = Volley.newRequestQueue(this);
 
         // 뒤로가기 버튼 이벤트
         btnBack.setOnClickListener(v -> finish());
 
-        // 인텐트로 전달받은 값 추출
+        // 1. entry_id가 넘어온 경우: 서버에서 직접 조회
+        int entryId = getIntent().getIntExtra("entry_id", -1);
+        if (entryId != -1) {
+            loadEntryDetailFromServer(entryId);
+            return;
+        }
+
+        // 2. 기존 방식: 인텐트로 전달받은 값 추출
         String emotion = getIntent().getStringExtra("emotion"); // 예: "yellow"
         String date = getIntent().getStringExtra("date");       // 예: "2025.06.04"
         String question = getIntent().getStringExtra("question");
@@ -47,5 +67,39 @@ public class DiaryDetailActivity extends AppCompatActivity {
         else if ("blue".equals(emotion)) emotionResId = R.drawable.color_circle_blue;
         else if ("red".equals(emotion)) emotionResId = R.drawable.color_circle_red;
         imgEmotionColor.setBackgroundResource(emotionResId);
+    }
+
+    // 서버에서 entry_id 기반 일기 상세 불러오기
+    private void loadEntryDetailFromServer(int entryId) {
+        String url = "http://10.0.2.2:8080/getEntryById.jsp?entry_id=" + entryId;
+
+        JsonArrayRequest request = new JsonArrayRequest(Request.Method.GET, url, null,
+                response -> {
+                    try {
+                        if (response.length() > 0) {
+                            JSONObject obj = response.getJSONObject(0);
+                            String date = obj.getString("date");
+                            String question = obj.getString("question");
+                            String content = obj.getString("content");
+                            String color = obj.getString("color");
+
+                            tvDate.setText(date + " 작성됨");
+                            tvQuestion.setText(question);
+                            tvContent.setText(content);
+
+                            try {
+                                imgEmotionColor.setColorFilter(Color.parseColor(color));
+                            } catch (IllegalArgumentException e) {
+                                imgEmotionColor.setColorFilter(Color.LTGRAY);
+                            }
+                        }
+                    } catch (JSONException e) {
+                        Toast.makeText(this, "데이터 파싱 오류", Toast.LENGTH_SHORT).show();
+                    }
+                },
+                error -> Toast.makeText(this, "서버 요청 실패", Toast.LENGTH_SHORT).show()
+        );
+
+        queue.add(request);
     }
 }

--- a/app/src/main/java/com/example/dearlog/activity/DiaryListActivity.java
+++ b/app/src/main/java/com/example/dearlog/activity/DiaryListActivity.java
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonArrayRequest;
+import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
 import com.example.dearlog.R;
 import com.example.dearlog.adapter.DiaryAdapter;
@@ -48,44 +49,83 @@ public class DiaryListActivity extends AppCompatActivity {
 
         btnBack.setOnClickListener(v -> finish());
         btnMenu.setOnClickListener(v -> {
-            // 메뉴 기능 추후 구현 예정
+            Toast.makeText(this, "메뉴 기능은 추후 구현 예정입니다", Toast.LENGTH_SHORT).show();
         });
 
-        // 인텐트로부터 entry_ids 받아오기
+        // 1. 기존 방식: entry_ids 배열이 있을 경우
         ArrayList<Integer> entryIds = (ArrayList<Integer>) getIntent().getSerializableExtra("entry_ids");
 
-        if (entryIds == null || entryIds.isEmpty()) {
-            Toast.makeText(this, "불러올 일기가 없습니다.", Toast.LENGTH_SHORT).show();
-            return;
-        }
-        Log.d("DiaryListActivity", "받은 entryIds: " + entryIds.toString());
-        // 서버에서 entry 데이터 불러오기
-        for (int entryId : entryIds) {
-            String entryUrl = "http://10.0.2.2:8080/getEntryById.jsp?entry_id=" + entryId;
+        if (entryIds != null && !entryIds.isEmpty()) {
+            Log.d("DiaryListActivity", "받은 entryIds: " + entryIds.toString());
 
-            JsonArrayRequest entryRequest = new JsonArrayRequest(
-                    Request.Method.GET,
-                    entryUrl,
-                    null,
-                    response -> {
-                        try {
-                            for (int i = 0; i < response.length(); i++) {
-                                JSONObject entry = response.getJSONObject(i);
-                                String date = entry.getString("date");
-                                String question = entry.getString("question");
-                                String writer = entry.getString("writer");
-                                String color = entry.getString("color");
+            for (int entryId : entryIds) {
+                String entryUrl = "http://10.0.2.2:8080/getEntryById.jsp?entry_id=" + entryId;
+
+                JsonArrayRequest entryRequest = new JsonArrayRequest(
+                        Request.Method.GET,
+                        entryUrl,
+                        null,
+                        response -> {
+                            try {
+                                for (int i = 0; i < response.length(); i++) {
+                                    JSONObject entry = response.getJSONObject(i);
+                                    String date = entry.getString("date");
+                                    String question = entry.getString("question");
+                                    String writer = entry.getString("writer");
+                                    String color = entry.getString("color");
+
+                                    diaryList.add(new DiaryItem(date, question, writer, color));
+                                }
+                                adapter.notifyDataSetChanged();
+                            } catch (JSONException e) {
+                                Toast.makeText(this, "일기 데이터 파싱 오류", Toast.LENGTH_SHORT).show();
+                            }
+                        },
+                        error -> Toast.makeText(this, "일기 데이터 로딩 실패", Toast.LENGTH_SHORT).show()
+                );
+                queue.add(entryRequest);
+            }
+
+        } else {
+            // 2. 새로운 방식: diary_id로 일괄 조회
+            String diaryId = getIntent().getStringExtra("diary_id");
+            if (diaryId != null) {
+                loadEntriesByDiaryId(diaryId);
+            } else {
+                Toast.makeText(this, "불러올 일기가 없습니다.", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    private void loadEntriesByDiaryId(String diaryId) {
+        String url = "http://10.0.2.2:8080/DearlogServer/getDiaryEntries.jsp?diary_id=" + diaryId;
+
+        JsonObjectRequest request = new JsonObjectRequest(Request.Method.GET, url, null,
+                response -> {
+                    try {
+                        if (response.getString("status").equals("success")) {
+                            JSONArray entries = response.getJSONArray("entries");
+                            diaryList.clear();
+                            for (int i = 0; i < entries.length(); i++) {
+                                JSONObject obj = entries.getJSONObject(i);
+                                String date = obj.getString("written_at");
+                                String question = obj.optString("question_text", "오늘의 질문");
+                                String writer = obj.optString("writer", "작성자");
+                                String color = obj.getString("emotion_code");
 
                                 diaryList.add(new DiaryItem(date, question, writer, color));
                             }
                             adapter.notifyDataSetChanged();
-                        } catch (JSONException e) {
-                            Toast.makeText(this, "일기 데이터 파싱 오류", Toast.LENGTH_SHORT).show();
+                        } else {
+                            Toast.makeText(this, "일기 목록 불러오기 실패", Toast.LENGTH_SHORT).show();
                         }
-                    },
-                    error -> Toast.makeText(this, "일기 데이터 로딩 실패", Toast.LENGTH_SHORT).show()
-            );
-            queue.add(entryRequest);
-        }
+                    } catch (JSONException e) {
+                        Toast.makeText(this, "데이터 파싱 오류", Toast.LENGTH_SHORT).show();
+                    }
+                },
+                error -> Toast.makeText(this, "서버 연결 실패", Toast.LENGTH_SHORT).show()
+        );
+
+        queue.add(request);
     }
 }

--- a/app/src/main/java/com/example/dearlog/activity/WriteDiaryActivity.java
+++ b/app/src/main/java/com/example/dearlog/activity/WriteDiaryActivity.java
@@ -21,7 +21,6 @@ import com.android.volley.toolbox.StringRequest;
 import com.android.volley.toolbox.Volley;
 import com.example.dearlog.R;
 import com.example.dearlog.dialog.SelectEmotionDialog;
-import com.example.dearlog.model.Emotion;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -40,8 +39,8 @@ public class WriteDiaryActivity extends AppCompatActivity {
     private ImageButton btnBack, btnMenu;
     private Button btnFinish;
 
-    private String selectedEmotionColorHex = null; // 선택한 감정 색상 코드
-    private int questionId = -1;     // 질문 ID 저장
+    private String selectedEmotionColorHex = null; // 감정 선택 시 색상 저장
+    private int questionId = -1;                   // 질문 ID 저장
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -81,30 +80,25 @@ public class WriteDiaryActivity extends AppCompatActivity {
         // 질문 불러오기
         loadTodayQuestion();
 
-        // [변경 후]
+        // 감정 선택 다이얼로그 연결 (color_circle 클릭 시)
         View colorCircle = findViewById(R.id.color_circle);
-
         colorCircle.setOnClickListener(v -> {
             SelectEmotionDialog dialog = new SelectEmotionDialog(this);
             dialog.setOnEmotionSelectedListener(colorHex -> {
                 selectedEmotionColorHex = colorHex;
 
-                if (colorCircle != null) {
-                    try {
-                        colorCircle.setBackgroundColor(Color.parseColor(colorHex));
-                    } catch (IllegalArgumentException e) {
-                        colorCircle.setBackgroundColor(Color.LTGRAY);
-                    }
+                // 색상 적용
+                try {
+                    colorCircle.setBackgroundColor(Color.parseColor(colorHex));
+                } catch (IllegalArgumentException e) {
+                    colorCircle.setBackgroundColor(Color.LTGRAY);
                 }
 
-                if (tvSelectedEmotion != null) {
-                    tvSelectedEmotion.setText("감정이 선택되었습니다");
-                }
+                // 안내 텍스트
+                tvSelectedEmotion.setText("감정이 선택되었습니다");
             });
             dialog.show();
         });
-
-
 
         // 뒤로가기
         btnBack.setOnClickListener(v -> finish());
@@ -114,7 +108,7 @@ public class WriteDiaryActivity extends AppCompatActivity {
             Toast.makeText(this, "메뉴 기능은 추후 구현 예정입니다", Toast.LENGTH_SHORT).show();
         });
 
-        // 작성 완료
+        // 작성 완료 → 저장 여부 확인
         btnFinish.setOnClickListener(v -> {
             new AlertDialog.Builder(this)
                     .setTitle("일기 저장")
@@ -126,7 +120,7 @@ public class WriteDiaryActivity extends AppCompatActivity {
     }
 
     private void loadTodayQuestion() {
-        String url = "http://10.0.2.2:8080/DearlogServer/getQuestion.jsp"; // 개발환경 주소
+        String url = "http://10.0.2.2:8080/DearlogServer/getQuestion.jsp";
 
         RequestQueue queue = Volley.newRequestQueue(this);
         JsonObjectRequest request = new JsonObjectRequest(Request.Method.GET, url, null,


### PR DESCRIPTION
- DiaryDetailActivity에 getEntryById.jsp 연동 기능 추가 (entry_id 기반)
- 서버에서 JSON으로 날짜, 질문, 내용, 감정 색상 받아오는 구조 구현
- 기존 intent 기반 "감정/날짜/질문/내용" 처리 로직 유지 (색상 리소스 방식 포함)
- entry_id 전달 시 서버 방식, 없을 경우 기존 방식 조건 분기 처리
- 감정 색상은 color 코드(hex) 기반 setColorFilter 방식 적용
- 기존 XML(activity_diary_detail.xml) 구조와 완전 호환 유지